### PR TITLE
fix: Number max value problem check need

### DIFF
--- a/doc/vital/Vim/Type/Number.txt
+++ b/doc/vital/Vim/Type/Number.txt
@@ -31,8 +31,8 @@ uint32({int})				  *Vital.Vim.Type.Number.uint32()*
 
 uint64({int})				  *Vital.Vim.Type.Number.uint64()*
 	Return uint64 (8 byte) casted integer from {int}.
+	Note:Support only |+num64|.
 
-Note: below functions will be moved to |Bitwise|.
 rotate8l({int}, {bits})			  *Vital.Vim.Type.Number.rotate8l()*
 	Return value that is {bits}-bit left bit-rotated with {int} as uint8.
 	Ex. >
@@ -57,9 +57,12 @@ rotate32r({int}, {bits})		  *Vital.Vim.Type.Number.rotate32r()*
 
 rotate64l({int}, {bits})		  *Vital.Vim.Type.Number.rotate64l()*
 	Return value that is {bits}-bit left bit-rotated with {int} as uint64.
+	Note:Support only |+num64|.
 
 rotate64r({int}, {bits})		  *Vital.Vim.Type.Number.rotate64r()*
 	Same as |Vital.Vim.Type.Number.rotate64l()|, shift right.
+	Note:Support only |+num64|.
+
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl:noet:fen:

--- a/test/Vim/Type/Number.vimspec
+++ b/test/Vim/Type/Number.vimspec
@@ -16,20 +16,22 @@ Describe Vim.Type.Number
   End
 
   Describe .uint32()
-    if has('num64')
-      It cast data
+    It cast data
+      if has('num64')
         Assert Equals(n.uint32(0x123456789), 0x23456789)
-      End
-    else
-      It cast data
-        Skip currently 32bit over not support in Vim
-      End
-    endif
+      else
+        Assert Equals(n.uint32(0x23456789), 0x23456789)
+      endif
+    End
   End
 
   Describe .uint64()
     It cast data
-      Skip currently 64bit over not support in Vim
+      if has('num64')
+        Assert Equals(n.uint64(0x2345678923456789), 0x2345678923456789)
+      else
+        Throws /^vital: Vim.Type.Number:/ n.uint64(0)
+      endif
     End
   End
 
@@ -92,7 +94,7 @@ Describe Vim.Type.Number
       End
     else
       It cast data
-        Skip currently 32bit over not support in Vim
+        Throws /^vital: Vim.Type.Number:/ n.rotate64l(0,0)
       End
     endif
   End
@@ -109,7 +111,7 @@ Describe Vim.Type.Number
       End
     else
       It cast data
-        Skip currently 32bit over not support in Vim
+        Throws /^vital: Vim.Type.Number:/ n.rotate64r(0,0)
       End
     endif
   End


### PR DESCRIPTION
Vim Number max as signed value.

If uint32/uint64 like program, it can not be said that there is no problem completely.