### PR TITLE
ci: fix git clone and vimproc for vim-jp/vital.vim#785

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -2,6 +2,7 @@ name: "build and test at vim"
 on: [push, pull_request]
 env:
   LUA_VERSION: 5.3.5
+  VIMPROC_VERSION: ver.10.0
 
 jobs:
   unixlike:
@@ -73,15 +74,30 @@ jobs:
         if: matrix.type == 'macvim'
         run: |
           echo "set luadll=$(brew --prefix lua)/lib/liblua.dylib" > ${GITHUB_WORKSPACE}/.themisrc
+      - name: Setup vital.vim
+        uses: actions/checkout@v2
+        with:
+          repository: vim-jp/vital.vim
+          path: ${{ github.workspace }}/vital.vim
+      - name: Setup vim-themis
+        uses: actions/checkout@v2
+        with:
+          repository: thinca/vim-themis
+          ref: ${{ env.THEMIS_VERSION }}
+          path: ${{ github.workspace }}/vim-themis
+      - name: Setup vimproc
+        uses: actions/checkout@v2
+        with:
+          repository: Shougo/vimproc.vim
+          path: ${{ github.workspace }}/vimproc
+      - name: Build vimproc
+        run: |
+          make -C ${GITHUB_WORKSPACE}/vimproc
       - name: Run test
         env:
           THEMIS_VIM: ${{ steps.vim.outputs.executable }}
           THEMIS_PROFILE: ${{ github.workspace }}/vim-profile-${{ runner.os }}-${{ matrix.vim }}-${{ matrix.type }}.txt
         run: |
-          git clone --depth 1 --branch ${THEMIS_VERSION} --single-branch https://github.com/thinca/vim-themis  ${GITHUB_WORKSPACE}/vim-themis
-          git clone --depth 1                            --single-branch https://github.com/vim-jp/vital.vim   ${GITHUB_WORKSPACE}/vital.vim
-          git clone --depth 1                                            https://github.com/Shougo/vimproc.vim ${GITHUB_WORKSPACE}/vimproc
-          (cd ${GITHUB_WORKSPACE}/vimproc && make)
           ${THEMIS_VIM} --version
           ${GITHUB_WORKSPACE}/vim-themis/bin/themis --runtimepath ${GITHUB_WORKSPACE}/vimproc --runtimepath ${GITHUB_WORKSPACE}/vital.vim --exclude ConcurrentProcess --reporter dot
       - name: Collect coverage
@@ -110,6 +126,10 @@ jobs:
       OS: ${{ matrix.os }}
       VIMVER: ${{ matrix.type }}-${{ matrix.vim }}
     steps:
+      - name: Setup git
+        shell: bash
+        run: |
+          git config --global core.autocrlf input
       - name: Checkout
         uses: actions/checkout@v2
       - name: Determining the library file
@@ -129,10 +149,6 @@ jobs:
           key: ${{ runner.os }}-64-files-${{ hashFiles('**/url.txt') }}
           restore-keys: |
             ${{ runner.os }}-64-files-
-      - name: Setup env
-        shell: cmd
-        run: |
-          type ENVFILE >> %GITHUB_ENV%
       - name: Setup lua
         shell: pwsh
         run: |
@@ -168,13 +184,27 @@ jobs:
           vim_version: '${{ matrix.vim }}'
           vim_type: '${{ matrix.type }}'
           download: '${{ matrix.vim_download || matrix.download }}'
-      - name: Build
+      - name: Setup vital.vim
+        uses: actions/checkout@v2
+        with:
+          repository: vim-jp/vital.vim
+          path: ${{ github.workspace }}/vital.vim
+      - name: Setup vim-themis
+        uses: actions/checkout@v2
+        with:
+          repository: thinca/vim-themis
+          ref: ${{ env.THEMIS_VERSION }}
+          path: ${{ github.workspace }}/vim-themis
+      - name: Setup vimproc
+        uses: actions/checkout@v2
+        with:
+          repository: Shougo/vimproc.vim
+          ref: ${{ env.VIMPROC_VERSION }}
+          path: ${{ github.workspace }}/vimproc
+      - name: Fetch vimproc dll
         shell: pwsh
         run: |
-          git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis  --quiet --branch ${Env:THEMIS_VERSION} --single-branch --depth 1 ${Env:GITHUB_WORKSPACE}\vim-themis
-          git -c advice.detachedHead=false clone https://github.com/vim-jp/vital.vim   --quiet                                --single-branch --depth 1 ${Env:GITHUB_WORKSPACE}\vital.vim
-          git -c advice.detachedHead=false clone https://github.com/Shougo/vimproc.vim --quiet --branch ver.9.2               --single-branch --depth 1 ${Env:GITHUB_WORKSPACE}\vimproc
-          Invoke-WebRequest -Uri "https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll" -OutFile "${Env:GITHUB_WORKSPACE}\vimproc\lib\vimproc_win64.dll"
+          Invoke-WebRequest -Uri "https://github.com/Shougo/vimproc.vim/releases/download/${Env:VIMPROC_VERSION}/vimproc_win64.dll" -OutFile "${Env:GITHUB_WORKSPACE}\vimproc\lib\vimproc_win64.dll"
       - name: Run test
         env:
           THEMIS_VIM: ${{ steps.vim.outputs.executable }}


### PR DESCRIPTION
fix Windows vimproc work in windows-latest

see
https://github.com/vim-jp/vital.vim/pull/785