### PR TITLE
ci: fix GitHub Workflow output method

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -140,11 +140,11 @@ jobs:
         shell: pwsh
         run: |
           $lua_url = 'https://sourceforge.net/projects/luabinaries/files/' + ${Env:LUA_VERSION} + '/Windows%20Libraries/Dynamic/lua-' + ${Env:LUA_VERSION} + '_Win64_dllw6_lib.zip/download'
-          Write-Host "url=$($lua_url)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "url=$($lua_url)" >> ${Env:GITHUB_OUTPUT}
           Write-Output $lua_url | Out-File url.txt
           $dir = ${Env:GITHUB_WORKSPACE} + '\lib'
           New-Item $dir -ItemType Directory
-          Write-Host "dir=$($dir)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "dir=$($dir)" >> ${Env:GITHUB_OUTPUT}
       - name: Set files cache
         uses: actions/cache@v3
         with:
@@ -173,7 +173,7 @@ jobs:
         shell: pwsh
         id: pip-cache
         run: |
-          python3 -c "from pip._internal.locations import USER_CACHE_DIR; print('dir=' + USER_CACHE_DIR)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          python3 -c "from pip._internal.locations import USER_CACHE_DIR; print('dir=' + USER_CACHE_DIR)" >> ${Env:GITHUB_OUTPUT}
       - name: Set pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get pip cache
         id: pip-cache
         run: |
-          python3 -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+          python3 -c "from pip._internal.locations import USER_CACHE_DIR; print('dir=' + USER_CACHE_DIR)" >> $GITHUB_OUTPUT
       - name: Set pip cache
         uses: actions/cache@v3
         with:
@@ -140,11 +140,11 @@ jobs:
         shell: pwsh
         run: |
           $lua_url = 'https://sourceforge.net/projects/luabinaries/files/' + ${Env:LUA_VERSION} + '/Windows%20Libraries/Dynamic/lua-' + ${Env:LUA_VERSION} + '_Win64_dllw6_lib.zip/download'
-          Write-Host "::set-output name=url::$($lua_url)"
+          Write-Host "url=$($lua_url)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           Write-Output $lua_url | Out-File url.txt
           $dir = ${Env:GITHUB_WORKSPACE} + '\lib'
           New-Item $dir -ItemType Directory
-          Write-Host "::set-output name=dir::$($dir)"
+          Write-Host "dir=$($dir)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Set files cache
         uses: actions/cache@v3
         with:
@@ -170,9 +170,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Get pip cache
+        shell: pwsh
         id: pip-cache
         run: |
-          python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+          python3 -c "from pip._internal.locations import USER_CACHE_DIR; print('dir=' + USER_CACHE_DIR)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Set pip cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
fix output

ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/